### PR TITLE
Hide elevator if a window is close

### DIFF
--- a/autoload/elevator.vim
+++ b/autoload/elevator.vim
@@ -1,5 +1,8 @@
 vim9script noclear
 
+# hide elevator when a window is closed
+autocmd WinLeave * call S__close()
+
 # defaults:
 if !exists('g:elevator#timeout_msec')
   g:elevator#timeout_msec = 2000


### PR DESCRIPTION
when a window is closed, the elevator is ever print
example: when we close a nerdtree window or a terminal window (:Term)